### PR TITLE
docs: fix received spelling in docs

### DIFF
--- a/docs/blog/data-data-everywhere.rst
+++ b/docs/blog/data-data-everywhere.rst
@@ -5,7 +5,7 @@ Data, Data Everywhere
 How data is stored
 ++++++++++++++++++
 
-Data streams itself right from when the gates of a stock exchange open to when it closes. Such data contains vital information that is archived each day. Some of the many types of information recieved after trading hours are - *opening price*, *closing price*, *volumne of shares*, *highest price*, *lowest price*, etc. for each enterprise.
+Data streams itself right from when the gates of a stock exchange open to when it closes. Such data contains vital information that is archived each day. Some of the many types of information received after trading hours are - *opening price*, *closing price*, *volumne of shares*, *highest price*, *lowest price*, etc. for each enterprise.
 
 **bulbea** helps you access such information (both - archived and the latest). Simply create a :py:class:`Share <bulbea.Share>` with a known :code:`source` and :code:`ticker` as follows:
 


### PR DESCRIPTION
Changes:
- `recieved` -> `received` in `docs/blog/data-data-everywhere.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
